### PR TITLE
Fix empty string parsing in string literals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,4 +204,52 @@ mod test {
         interp.eval("x = {'a': 1, 'b': 2}").unwrap();
         assert_eq!(interp.eval("x.values()").unwrap().to_string(), "[1, 2]");
     }
+
+    #[test]
+    fn test_strings_non_empty_single_quote() {
+        let interp = Interpreter::new();
+        assert_eq!(
+            interp
+                .eval_with_context("'a'", &Default::default())
+                .unwrap()
+                .to_string(),
+            "a"
+        );
+        assert_eq!(
+            interp
+                .eval_with_context("'hello'", &Default::default())
+                .unwrap()
+                .to_string(),
+            "hello"
+        );
+        assert!(interp.eval_boolean("'a' == 'a'").unwrap());
+    }
+
+    #[test]
+    fn test_strings_single_quote_empty() {
+        let interp = Interpreter::new();
+        assert_eq!(
+            interp
+                .eval_with_context("''", &Default::default())
+                .unwrap()
+                .to_string(),
+            ""
+        );
+        assert!(interp.eval_boolean("'' == ''").unwrap());
+        assert_eq!(
+            interp
+                .eval_with_context("len('')", &Default::default())
+                .unwrap()
+                .to_string(),
+            "0"
+        );
+    }
+
+    #[test]
+    fn test_strings_empty_comparison() {
+        let mut interp = Interpreter::new();
+        interp.eval("x = ''").unwrap();
+        assert!(interp.eval_boolean("x == ''").unwrap());
+        assert!(interp.eval_boolean("x != 'foo'").unwrap());
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@ use nom::error::Error;
 use nom::error::ErrorKind;
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take_while1},
+    bytes::complete::{tag, take_while, take_while1},
     character::complete::{char, multispace0},
     combinator::opt,
     multi::separated_list0,
@@ -739,7 +739,7 @@ fn number(input: &str) -> IResult<&str, Expr> {
 //---------------------------------------------------------
 fn string_lit(input: &str) -> IResult<&str, Expr> {
     let (input, _) = char('\'')(input)?;
-    let (input, s) = take_while1(|c: char| c != '\'')(input)?;
+    let (input, s) = take_while(|c: char| c != '\'')(input)?;
     let (input, _) = char('\'')(input)?;
     Ok((input, Expr::StringLit(s.to_string())))
 }


### PR DESCRIPTION
Parser was using take_while1 which requires at least one character, causing '' to fail. 
Changed to take_while to accept zero-length strings.