### PR TITLE
Add True, False built-in constants (#4)

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -642,6 +642,10 @@ impl Interpreter {
             },
         );
 
+        // Python boolean constants
+        base_env.set("True", Value::Number(1.0));
+        base_env.set("False", Value::Number(0.0));
+
         Interpreter {
             env: Rc::new(RefCell::new(base_env)),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,4 +450,54 @@ mod test {
         assert_eq!(interp.eval("(not 1) == 0").unwrap().to_string(), "1");
         assert_eq!(interp.eval("(not 2) == 1").unwrap().to_string(), "0");
     }
+
+    #[test]
+    fn test_builtin_constants() {
+        let mut interp = Interpreter::new();
+        // Test True constant
+        assert_eq!(interp.eval("True").unwrap().to_string(), "1");
+        // Test False constant
+        assert_eq!(interp.eval("False").unwrap().to_string(), "0");
+    }
+
+    #[test]
+    fn test_builtin_constants_comparisons() {
+        let mut interp = Interpreter::new();
+        // True == 1
+        assert_eq!(interp.eval("True == 1").unwrap().to_string(), "1");
+        // False == 0
+        assert_eq!(interp.eval("False == 0").unwrap().to_string(), "1");
+        // True != False
+        assert_eq!(interp.eval("True != False").unwrap().to_string(), "1");
+        // True == False should be false
+        assert_eq!(interp.eval("True == False").unwrap().to_string(), "0");
+    }
+
+    #[test]
+    fn test_builtin_constants_with_not() {
+        let mut interp = Interpreter::new();
+        // not True is False
+        assert_eq!(interp.eval("not True").unwrap().to_string(), "0");
+        // not False is True
+        assert_eq!(interp.eval("not False").unwrap().to_string(), "1");
+    }
+
+    #[test]
+    fn test_builtin_constants_in_expressions() {
+        let mut interp = Interpreter::new();
+        // Test variable comparison with True/False
+        interp.eval("foo = 0").unwrap();
+        assert_eq!(interp.eval("foo == True").unwrap().to_string(), "0");
+        assert_eq!(interp.eval("foo == False").unwrap().to_string(), "1");
+
+        interp.eval("foo = 1").unwrap();
+        assert_eq!(interp.eval("foo == True").unwrap().to_string(), "1");
+        assert_eq!(interp.eval("foo == False").unwrap().to_string(), "0");
+
+        // Test arithmetic operations with True/False
+        assert_eq!(interp.eval("True + 1").unwrap().to_string(), "2");
+        assert_eq!(interp.eval("False + 1").unwrap().to_string(), "1");
+        assert_eq!(interp.eval("True * 5").unwrap().to_string(), "5");
+        assert_eq!(interp.eval("False * 5").unwrap().to_string(), "0");
+    }
 }


### PR DESCRIPTION
* Add True, False built-in constants

Add Python boolean constants to interpreter initialization:
- True = 1
- False = 0

This matches Python semantics where True/False are equal to 1/0 for numeric operations. Enables expressions like: foo == True, bar == False.