### PR TITLE
Add and, or logical operators (#5)

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -59,7 +59,7 @@ pub enum Expr {
     },
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BinOp {
     Add,
     Sub,
@@ -74,6 +74,8 @@ pub enum BinOp {
     Le,
     Eq,
     Ne,
+    And,
+    Or,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -105,6 +107,8 @@ impl fmt::Display for BinOp {
             BinOp::Le => write!(f, "<="),
             BinOp::Eq => write!(f, "=="),
             BinOp::Ne => write!(f, "!="),
+            BinOp::And => write!(f, "and"),
+            BinOp::Or => write!(f, "or"),
         }
     }
 }


### PR DESCRIPTION
Implement Python-style 'and' and 'or' binary operators with proper short-circuit evaluation and precedence handling.

Operator precedence (low to high): or, and, not, comparisons Short-circuit semantics match Python:
- 'and' returns left if falsy, otherwise right
- 'or' returns left if truthy, otherwise right

Includes boundary checking to prevent matching keywords within identifiers (e.g., "android", "orbit").